### PR TITLE
Typesig macro

### DIFF
--- a/ast/src/expression/binary.rs
+++ b/ast/src/expression/binary.rs
@@ -1,6 +1,7 @@
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
+    typesig,
     typing::{TypeEnum, TypeError, TypePrimitive, TypeVar},
     OP_SEPARATOR,
 };
@@ -32,25 +33,10 @@ impl Expression for Binary {
             Binary::GreaterThan
             | Binary::GreaterThanEquals
             | Binary::LessThan
-            | Binary::LessThanEquals => TypeEnum::Arrow(
-                Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
-                Box::new(TypeEnum::Arrow(
-                    Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
-                    Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
-                )),
-            ),
+            | Binary::LessThanEquals => typesig!(int -> int -> int),
             // function binary<T>(a: T, b: T): uint;
             // 'a -> 'a -> uint
-            Binary::Equals | Binary::NotEquals => {
-                let tv = TypeVar::new();
-                TypeEnum::Arrow(
-                    Box::new(TypeEnum::Var(tv.clone())),
-                    Box::new(TypeEnum::Arrow(
-                        Box::new(TypeEnum::Var(tv.clone())),
-                        Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
-                    )),
-                )
-            }
+            Binary::Equals | Binary::NotEquals => typesig!(:a -> :a -> int),
         })
     }
 

--- a/ast/src/expression/constant.rs
+++ b/ast/src/expression/constant.rs
@@ -1,7 +1,7 @@
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
-    typing::{TypeEnum, TypeError, TypePrimitive},
+    typing::{TypeEnum, TypeError, TypePrimitive}, typesig,
 };
 
 use super::Expression;
@@ -18,7 +18,7 @@ pub enum OnComplete {
 
 impl Expression for OnComplete {
     fn resolve(&self, _: &TypeContext) -> Result<TypeEnum, TypeError> {
-        Ok(TypeEnum::Simple(TypePrimitive::UInt64))
+        Ok(typesig!(int))
     }
 
     fn compile(

--- a/ast/src/expression/primitive.rs
+++ b/ast/src/expression/primitive.rs
@@ -3,6 +3,7 @@ use std::ascii;
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
+    typesig,
     typing::{TypeEnum, TypeError, TypePrimitive},
 };
 
@@ -41,10 +42,10 @@ impl From<u64> for Primitive {
 
 impl Expression for Primitive {
     fn resolve(&self, _: &TypeContext) -> Result<TypeEnum, TypeError> {
-        Ok(TypeEnum::Simple(match self {
-            Primitive::UInt64(_) => TypePrimitive::UInt64,
-            Primitive::Byteslice(_) => TypePrimitive::Byteslice,
-        }))
+        Ok(match self {
+            Primitive::UInt64(_) => typesig!(int),
+            Primitive::Byteslice(_) => typesig!(bytes),
+        })
     }
 
     fn compile(

--- a/ast/src/expression/ret.rs
+++ b/ast/src/expression/ret.rs
@@ -1,7 +1,8 @@
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
-    typing::{TypeEnum, TypeError, TypePrimitive},
+    typesig,
+    typing::{TypeEnum, TypeError, TypePrimitive, TypeVar},
     OP_SEPARATOR,
 };
 
@@ -12,10 +13,7 @@ pub struct Ret;
 
 impl Expression for Ret {
     fn resolve(&self, _: &TypeContext) -> Result<TypeEnum, TypeError> {
-        Ok(TypeEnum::Arrow(
-            Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
-            Box::new(TypeEnum::Simple(TypePrimitive::Halt)),
-        ))
+        Ok(typesig!(int -> halt))
     }
 
     fn compile(

--- a/ast/src/expression/ret.rs
+++ b/ast/src/expression/ret.rs
@@ -1,5 +1,3 @@
-use strum_macros::EnumString;
-
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
@@ -9,28 +7,25 @@ use crate::{
 
 use super::Expression;
 
-#[derive(Debug, Clone, PartialEq, EnumString)]
-pub enum Ret {
-    Approve,
-    Reject,
-}
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ret;
 
 impl Expression for Ret {
     fn resolve(&self, _: &TypeContext) -> Result<TypeEnum, TypeError> {
-        Ok(TypeEnum::Simple(TypePrimitive::Halt))
+        Ok(TypeEnum::Arrow(
+            Box::new(TypeEnum::Simple(TypePrimitive::UInt64)),
+            Box::new(TypeEnum::Simple(TypePrimitive::Halt)),
+        ))
     }
 
     fn compile(
         &self,
-        _: &CompilationContext,
-        _: &mut Vec<String>,
+        _context: &CompilationContext,
+        prepared_stack: &mut Vec<String>,
     ) -> Result<String, CompilationError> {
         Ok(format!(
-            "int {value}{OP_SEPARATOR}return",
-            value = match self {
-                Ret::Approve => "1",
-                Ret::Reject => "0",
-            }
+            "{}{OP_SEPARATOR}return",
+            prepared_stack.pop().ok_or(CompilationError::MissingStack)?
         ))
     }
 }
@@ -44,8 +39,8 @@ mod tests {
 
     #[test]
     fn test() {
-        let e = Ret::Approve;
-        println!("{:?}", e.resolve(&TypeContext::default()));
-        println!("{}", e.compile_raw().unwrap());
+        // let e = Ret::Approve;
+        // println!("{:?}", e.resolve(&TypeContext::default()));
+        // println!("{}", e.compile_raw().unwrap());
     }
 }

--- a/ast/src/expression/ret.rs
+++ b/ast/src/expression/ret.rs
@@ -34,13 +34,16 @@ impl Expression for Ret {
 mod tests {
     use crate::{
         context::TypeContext,
-        expression::{ret::Ret, Expression},
+        expression::{apply::Apply, primitive::Primitive, ret::Ret, Expr, Expression},
     };
 
     #[test]
     fn test() {
-        // let e = Ret::Approve;
-        // println!("{:?}", e.resolve(&TypeContext::default()));
-        // println!("{}", e.compile_raw().unwrap());
+        let e = Expr::Apply(Box::new(Apply(
+            Expr::Ret(Ret),
+            Expr::Primitive(Primitive::UInt64(1)),
+        )));
+        println!("{:?}", e.resolve(&TypeContext::default()));
+        println!("{}", e.compile_raw().unwrap());
     }
 }

--- a/ast/src/expression/txn.rs
+++ b/ast/src/expression/txn.rs
@@ -3,6 +3,7 @@ use strum_macros::EnumString;
 use crate::{
     compilation_error::CompilationError,
     context::{CompilationContext, TypeContext},
+    typesig,
     typing::{TypeEnum, TypeError, TypePrimitive},
 };
 
@@ -25,12 +26,12 @@ pub enum Txn {
 
 impl Expression for Txn {
     fn resolve(&self, _: &TypeContext) -> Result<TypeEnum, TypeError> {
-        Ok(TypeEnum::Simple(match self {
+        Ok(match self {
             Txn::Sender | Txn::Receiver | Txn::CloseRemainderTo | Txn::Accounts => {
-                TypePrimitive::Byteslice
+                typesig!(bytes)
             }
-            _ => TypePrimitive::UInt64,
-        }))
+            _ => typesig!(int),
+        })
     }
 
     fn compile(

--- a/ast/src/macros.rs
+++ b/ast/src/macros.rs
@@ -65,6 +65,9 @@ macro_rules! binop {
     (($a:expr) == ($b:expr)) => {
         apply!(@fn Expr::Binary(Binary::Equals); @arg $b; @arg $a)
     };
+    (($a:expr) != ($b:expr)) => {
+        apply!(@fn Expr::Binary(Binary::NotEquals); @arg $b; @arg $a)
+    };
     (($a:expr) > ($b:expr)) => {
         apply!(@fn Expr::Binary(Binary::GreaterThan); @arg $b; @arg $a)
     };
@@ -254,8 +257,8 @@ macro_rules! typesig {
             // This is less efficient than writing the type by hand
             // Another possible option:
             // https://stackoverflow.com/a/64957454 (generate custom struct with fields for each unique tvar?)
-            let mut tvars: std::collections::HashMap<&'static str, TypeVar> = std::collections::HashMap::new();
-            typesig!(@_context tvars $a $($b)+)
+            let mut _tvars: std::collections::HashMap<&'static str, TypeVar> = std::collections::HashMap::new();
+            typesig!(@_context _tvars $a $($b)+)
         }
     };
 }

--- a/ast/src/macros.rs
+++ b/ast/src/macros.rs
@@ -158,6 +158,15 @@ macro_rules! r#if {
         )
     };
 }
+#[macro_export]
+macro_rules! ret {
+    ($e:expr) => {
+        apply!(
+            @fn Expr::Ret(Ret);
+            @arg $e;
+        )
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -167,6 +176,7 @@ mod tests {
     use crate::expression::cond::Cond;
     use crate::expression::if_else::If;
     use crate::expression::primitive::Primitive;
+    use crate::expression::ret::Ret;
     use crate::expression::seq::Seq;
     use crate::expression::var::{LVal, RVal, Var};
     use crate::expression::{Expr, Expression};
@@ -194,6 +204,7 @@ mod tests {
                 @then bytes!(">4".into());
                 @else bytes!("<=4".into());
             );
+            ret!(int!(1));
         });
         println!("{}", x.compile_raw().unwrap());
 


### PR DESCRIPTION
Write OCaml-inspired type signatures inline.

For example,

```rs
typesig!(:a -> :b -> :a -> :c -> int)
```

resolves to:

```rs
Arrow(
    Var(
        TypeVar {
            id: 0,
            value: RefCell { value: None }
        }
    ),
    Arrow(
        Var(
            TypeVar {
                id: 1,
                value: RefCell { value: None }
            }
        ),
        Arrow(
            Var(
                TypeVar {
                    id: 0,
                    value: RefCell { value: None }
                }
            ),
            Arrow(
                Var(
                    TypeVar {
                        id: 2,
                        value: RefCell { value: None }
                    }
                ),
                Simple(UInt64)
            )
        )
    )
)
```